### PR TITLE
Added the reason of the changing due date to comment

### DIFF
--- a/knock_knock/knock_knock/doctype/docket/docket.js
+++ b/knock_knock/knock_knock/doctype/docket/docket.js
@@ -2,9 +2,51 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Docket', {
-  // refresh: function(frm){
-  //
-  // },
+  refresh: function(frm){
+    frm.set_df_property("due_date", "read_only", frm.is_new() ? 0 : 1);
+    frm.set_df_property("change_due", "hidden", frm.is_new() ? 1 : 0);
+  },
 
-  
+  change_due : function(frm){
+  let command = new frappe.ui.Dialog({
+      title: 'Enter The Reason',
+      fields: [
+          {
+              label: 'Reason',
+              fieldname: 'reason',
+              fieldtype: 'Small Text'
+          },
+      ],
+      primary_action_label: 'Submit',
+      primary_action(values) {
+          command.hide();
+          if(values.reason){
+            frappe.call({
+              method:'knock_knock.knock_knock.doctype.docket.docket.add_comment_docket',
+              args:{'reason':values.reason,
+                    'name':frm.doc.name
+            },
+              callback:function(r){
+                if (r) {
+                  frm.reload_doc()
+                 }
+              }
+            })
+          }
+      }
+  });
+
+  command.show();
+}
+
+
+
+
+
+
+
+
+
+
+
 });

--- a/knock_knock/knock_knock/doctype/docket/docket.json
+++ b/knock_knock/knock_knock/doctype/docket/docket.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "naming_series:",
  "creation": "2022-10-27 16:11:52.536738",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -11,9 +12,11 @@
   "description",
   "column_break_3",
   "due_date",
+  "change_due",
   "status",
   "remind_before_unit",
-  "remind_before"
+  "remind_before",
+  "naming_series"
  ],
  "fields": [
   {
@@ -62,11 +65,22 @@
   {
    "fieldname": "column_break_3",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "DC.#####"
+  },
+  {
+   "fieldname": "change_due",
+   "fieldtype": "Button",
+   "label": "Change Due"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-10-28 11:02:49.137013",
+ "modified": "2022-10-28 13:18:35.830583",
  "modified_by": "Administrator",
  "module": "Knock Knock",
  "name": "Docket",

--- a/knock_knock/knock_knock/doctype/docket/docket.json
+++ b/knock_knock/knock_knock/doctype/docket/docket.json
@@ -7,16 +7,16 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "posting_date",
+  "naming_series",
   "subject",
   "description",
+  "remind_before",
   "column_break_3",
+  "posting_date",
   "due_date",
   "change_due",
   "status",
-  "remind_before_unit",
-  "remind_before",
-  "naming_series"
+  "remind_before_unit"
  ],
  "fields": [
   {
@@ -57,6 +57,7 @@
    "options": "\nDay\nMinutes"
   },
   {
+   "depends_on": "eval:doc.remind_before_unit",
    "fieldname": "remind_before",
    "fieldtype": "Float",
    "label": "Remind Before",
@@ -80,7 +81,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-10-28 13:18:35.830583",
+ "modified": "2022-10-29 11:04:48.785436",
  "modified_by": "Administrator",
  "module": "Knock Knock",
  "name": "Docket",

--- a/knock_knock/knock_knock/doctype/docket/docket.py
+++ b/knock_knock/knock_knock/doctype/docket/docket.py
@@ -1,8 +1,19 @@
 # Copyright (c) 2022, efeone Software Lab and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 class Docket(Document):
 	pass
+
+
+
+
+@frappe.whitelist()
+def add_comment_docket(reason,name):
+	if frappe.db.exists('Docket',name):
+		doc_name= frappe.get_doc('Docket',name)
+		doc_name.add_comment('Comment',reason)
+		doc_name.save()
+		return True


### PR DESCRIPTION
## Feature description
Created a doctype named Docket .setup all the fields.Then added a new button 'change due' . The due date field is now read-only after the save of each docket.While clicking the Change due button , a popup field can see to enter the reason of changing the due  date . And then the reason can see in the comment section below.  


## Output screenshots (optional)
![Screenshot from 2022-10-29 11-07-03](https://user-images.githubusercontent.com/115983752/198816527-951bedd7-6359-44c9-b24f-831580e0ca46.png)
![Screenshot from 2022-10-29 11-08-12](https://user-images.githubusercontent.com/115983752/198816530-5bff96b0-c05a-4c0e-958c-8d248a170bb4.png)
![Screenshot from 2022-10-29 11-08-19](https://user-images.githubusercontent.com/115983752/198816533-f0f33f96-a4eb-4ed3-8d41-60230e7e39a0.png)




## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome: yes
  - Safari
