### PR TITLE
feat: setup day reminding

### DIFF
--- a/knock_knock/hooks.py
+++ b/knock_knock/hooks.py
@@ -106,23 +106,11 @@ app_license = "MIT"
 # Scheduled Tasks
 # ---------------
 
-# scheduler_events = {
-#	"all": [
-#		"knock_knock.tasks.all"
-#	],
-#	"daily": [
-#		"knock_knock.tasks.daily"
-#	],
-#	"hourly": [
-#		"knock_knock.tasks.hourly"
-#	],
-#	"weekly": [
-#		"knock_knock.tasks.weekly"
-#	]
-#	"monthly": [
-#		"knock_knock.tasks.monthly"
-#	]
-# }
+scheduler_events = {
+	"daily": [
+		"knock_knock.knock_knock.utils.get_all_dockets"
+	]
+}
 
 # Testing
 # -------
@@ -178,4 +166,3 @@ user_data_fields = [
 # auth_hooks = [
 #	"knock_knock.auth.validate"
 # ]
-

--- a/knock_knock/knock_knock/utils.py
+++ b/knock_knock/knock_knock/utils.py
@@ -1,0 +1,33 @@
+import frappe
+from frappe.model.document import Document
+from frappe.utils import today, getdate
+
+@frappe.whitelist()
+def get_all_dockets():
+    if frappe.db.exists("Docket", {"status": "Open"}):
+        dockets = frappe.db.get_all("Docket", filters = {"status": "Open"})
+        if dockets:
+            for docket in dockets:
+                docket_doc = frappe.get_doc('Docket', docket.name)
+                today = getdate(frappe.utils.today())
+                due_date = getdate(docket_doc.due_date)
+                if docket_doc.remind_before_unit == 'Day':
+                    if docket_doc.remind_before:
+                        notification_date = frappe.utils.add_to_date(due_date, days=-1*docket_doc.remind_before)
+                        if getdate(notification_date) == today:
+                            create_notification_log(docket_doc.subject, docket_doc.owner, docket_doc.description, docket_doc.doctype, docket_doc.name)
+                    else:
+                        if due_date==today:
+                            create_notification_log(docket_doc.subject, docket_doc.owner, docket_doc.description, docket_doc.doctype, docket_doc.name)
+
+@frappe.whitelist()
+def create_notification_log(subject, for_user, email_content, document_type, document_name):
+    notification_doc = frappe.new_doc('Notification Log')
+    notification_doc.subject = subject
+    notification_doc.type = 'Mention'
+    notification_doc.for_user = for_user
+    notification_doc.email_content = email_content
+    notification_doc.document_type = document_type
+    notification_doc.document_name = document_name
+    notification_doc.save()
+    frappe.db.commit()


### PR DESCRIPTION
## Feature description
As a Docket creator I would like to get reminded my dockets based on remind before  a day details via email to the owner

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2022-10-29 15-29-47](https://user-images.githubusercontent.com/115451782/198825470-137688f2-9bf8-441b-a240-13303e6127d3.png)
![Screenshot from 2022-10-29 15-30-00](https://user-images.githubusercontent.com/115451782/198825475-63873d1a-c312-4e6b-868a-f3a453ea0b8c.png)



## Is there any existing behavior change of other features due to this code change?
no


## Was this feature tested on the browsers?
  - Chrome :yes
  - Safari
