### PR TITLE
feat: Change Docket status to Overdue

### DIFF
--- a/knock_knock/knock_knock/doctype/docket/docket.py
+++ b/knock_knock/knock_knock/doctype/docket/docket.py
@@ -2,10 +2,13 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe.utils import *
 from frappe.model.document import Document
+from knock_knock.knock_knock.utils import change_docket_status
 
 class Docket(Document):
-	pass
+	def validate(self):
+		change_docket_status(self)
 
 @frappe.whitelist()
 def add_docket_comment(reason, name):

--- a/knock_knock/knock_knock/utils.py
+++ b/knock_knock/knock_knock/utils.py
@@ -11,6 +11,10 @@ def get_all_dockets():
                 docket_doc = frappe.get_doc('Docket', docket.name)
                 today = getdate(frappe.utils.today())
                 due_date = getdate(docket_doc.due_date)
+
+                #To change status to Overdue
+                if due_date>=today:
+                    change_docket_status(docket_doc)
                 if docket_doc.remind_before_unit == 'Day':
                     if docket_doc.remind_before:
                         notification_date = frappe.utils.add_to_date(due_date, days=-1*docket_doc.remind_before)
@@ -31,3 +35,12 @@ def create_notification_log(subject, for_user, email_content, document_type, doc
     notification_doc.document_name = document_name
     notification_doc.save()
     frappe.db.commit()
+
+def change_docket_status(self):
+	if self.status == 'Open':
+		current_date = getdate(today())
+		due_date = getdate(self.due_date)
+		if current_date>due_date:
+			self.status = 'Overdue'
+			frappe.db.set_value(self.doctype, self.name, 'status', 'Overdue')
+			frappe.db.commit()


### PR DESCRIPTION
## Feature description
set status of docket as 'Overdue' immediately after due date, So that we can list overdue dockets.
On scheduler check for the dockets with due date and if status is Open then set the status to 'Overdue'



## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2022-10-29 17-12-35](https://user-images.githubusercontent.com/95274912/198829543-612b3bdf-8226-4270-add6-8b1c05a2c665.png)


## Is there any existing behavior change of other features due to this code change?
yes

## Was this feature tested on the browsers?
  - Chrome yes
  
