### PR TITLE
feat:Set role permission to docket creator

### DIFF
--- a/knock_knock/fixtures/custom_docperm.json
+++ b/knock_knock/fixtures/custom_docperm.json
@@ -1,0 +1,29 @@
+[
+ {
+  "amend": 0,
+  "cancel": 0,
+  "create": 1,
+  "delete": 1,
+  "docstatus": 0,
+  "doctype": "Custom DocPerm",
+  "email": 1,
+  "export": 1,
+  "if_owner": 1,
+  "import": 1,
+  "modified": "2022-10-29 13:01:40.605627",
+  "name": "9b91e1884e",
+  "parent": "Docket",
+  "parentfield": "permissions",
+  "parenttype": "DocType",
+  "permlevel": 0,
+  "print": 1,
+  "read": 1,
+  "report": 1,
+  "role": "Docket User",
+  "select": 1,
+  "set_user_permissions": 0,
+  "share": 1,
+  "submit": 0,
+  "write": 1
+ }
+]

--- a/knock_knock/fixtures/role.json
+++ b/knock_knock/fixtures/role.json
@@ -1,0 +1,26 @@
+[
+ {
+  "bulk_actions": 1,
+  "dashboard": 1,
+  "desk_access": 1,
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Role",
+  "form_sidebar": 1,
+  "home_page": null,
+  "is_custom": 0,
+  "list_sidebar": 1,
+  "modified": "2022-10-29 13:00:49.095056",
+  "name": "Docket User",
+  "notifications": 1,
+  "parent": null,
+  "parentfield": null,
+  "parenttype": null,
+  "restrict_to_domain": null,
+  "role_name": "Docket User",
+  "search_bar": 1,
+  "timeline": 1,
+  "two_factor_auth": 0,
+  "view_switcher": 1
+ }
+]

--- a/knock_knock/hooks.py
+++ b/knock_knock/hooks.py
@@ -166,3 +166,8 @@ user_data_fields = [
 # auth_hooks = [
 #	"knock_knock.auth.validate"
 # ]
+
+fixtures = [
+		{"dt": "Role","filters": [["name", "in", ['Docket User']]]},
+		{"dt": "Custom DocPerm","filters": [["role", "in", ['Docket User']]]}
+	]


### PR DESCRIPTION
Features:
-Set role permission to docket creator
-create a new role docket user
-set docket user only if  it is creator
-set all permission checked.


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
 
![Screenshot from 2022-10-29 17-31-54](https://user-images.githubusercontent.com/114916803/198831494-132ab469-6ae5-42bd-9973-9a630fb34387.png)

