### PR TITLE
fix: Change due is visible when status is open and overdue

### DIFF
--- a/knock_knock/knock_knock/doctype/docket/docket.js
+++ b/knock_knock/knock_knock/doctype/docket/docket.js
@@ -4,49 +4,53 @@
 frappe.ui.form.on('Docket', {
   refresh: function(frm){
     frm.set_df_property("due_date", "read_only", frm.is_new() ? 0 : 1);
-    frm.set_df_property("change_due", "hidden", frm.is_new() ? 1 : 0);
-    if (frm.doc.owner != frappe.session.user){
-      frm.set_df_property("change_due", "hidden", 1)
+    if (frm.doc.owner == frappe.session.user && !frm.is_new()){
+      if (frm.doc.status == 'Open' || frm.doc.status == 'Overdue') {
+        frm.set_df_property('change_due', 'hidden', 0)
+      }
+      else {
+        frm.set_df_property('change_due', 'hidden', 1)
+      }
     }
   },
 
   change_due : function(frm){
-  let command = new frappe.ui.Dialog({
-      title: 'Enter the reason',
-      fields: [
-         {
-            label: 'New Date',
-            fieldname: 'new_date',
-            fieldtype: 'Date',
-            reqd: 1
-         },
-         {
-              label: 'Reason',
-              fieldname: 'reason',
-              fieldtype: 'Small Text'
-          },
+        let command = new frappe.ui.Dialog({
+          title: 'Enter the reason',
+          fields: [
+             {
+                label: 'New Date',
+                fieldname: 'new_date',
+                fieldtype: 'Date',
+                reqd: 1
+             },
+             {
+                  label: 'Reason',
+                  fieldname: 'reason',
+                  fieldtype: 'Small Text'
+              },
 
-      ],
-      primary_action_label: 'Submit',
-      primary_action(values) {
-          command.hide();
-          if(values){
-            frappe.call({
-              method:'knock_knock.knock_knock.doctype.docket.docket.add_docket_comment',
-              args:{
-                    'reason':values.reason,
-                    'name':frm.doc.name,
-                    'new_date': values.new_date
-                   },
-              callback:function(r){
-                if (r) {
-                  frm.reload_doc()
-                }
+          ],
+          primary_action_label: 'Submit',
+          primary_action(values) {
+              command.hide();
+              if(values){
+                frappe.call({
+                  method:'knock_knock.knock_knock.doctype.docket.docket.add_docket_comment',
+                  args:{
+                        'reason':values.reason,
+                        'name':frm.doc.name,
+                        'new_date': values.new_date
+                       },
+                  callback:function(r){
+                    if (r) {
+                      frm.reload_doc()
+                    }
+                  }
+                })
               }
-            })
           }
-      }
-  });
-  command.show();
+      });
+      command.show();
 }
 });

--- a/knock_knock/knock_knock/doctype/docket/docket.json
+++ b/knock_knock/knock_knock/doctype/docket/docket.json
@@ -34,13 +34,13 @@
   {
    "default": "Today",
    "fieldname": "posting_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "label": "Posting Date",
    "reqd": 1
   },
   {
    "fieldname": "due_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "label": "Due Date ",
    "reqd": 1
   },
@@ -76,12 +76,13 @@
   {
    "fieldname": "change_due",
    "fieldtype": "Button",
+   "hidden": 1,
    "label": "Change Due"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-10-29 15:15:47.096299",
+ "modified": "2022-10-31 15:33:33.107464",
  "modified_by": "Administrator",
  "module": "Knock Knock",
  "name": "Docket",

--- a/knock_knock/knock_knock/doctype/docket/docket.py
+++ b/knock_knock/knock_knock/doctype/docket/docket.py
@@ -12,6 +12,7 @@ def add_docket_comment(name, new_date, reason=None):
 	if frappe.db.exists('Docket', name):
 		doc_name = frappe.get_doc('Docket', name)
 		doc_name.due_date = new_date
+		doc_name.status = "Open"
 		if reason:
 			doc_name.add_comment('Comment', reason)
 		doc_name.save()


### PR DESCRIPTION
## Feature description
Now the change due is visible only when the status is open or overdue .Otherwise the change due button is hidden . And also the datatype of the posting date and Duedate is changed  into datetime.


## Output screenshots (optional)
![Screenshot from 2022-11-01 09-56-51](https://user-images.githubusercontent.com/115983752/199159020-3ebec4c4-09d7-4e85-b228-f51d18111f1c.png)
![Screenshot from 2022-11-01 09-56-58](https://user-images.githubusercontent.com/115983752/199159027-44f0b50a-a062-4983-befb-547974dacf6e.png)
![Screenshot from 2022-11-01 09-57-11](https://user-images.githubusercontent.com/115983752/199159028-f5e27490-75f9-4fd7-b7f4-f5b85e1322b3.png)



## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome :yes
  - Safari
