### PR TITLE
feat: Set the status to overdue immediately after duedate in ToDo

### DIFF
--- a/knock_knock/hooks.py
+++ b/knock_knock/hooks.py
@@ -108,7 +108,8 @@ app_license = "MIT"
 
 scheduler_events = {
 	"daily": [
-		"knock_knock.knock_knock.utils.get_all_dockets"
+		"knock_knock.knock_knock.utils.get_all_dockets",
+		"knock_knock.knock_knock.utils.get_all_todos"
 	],
 	"cron": {
 		"1-59 * * * *":[

--- a/knock_knock/knock_knock/doctype/docket/docket.py
+++ b/knock_knock/knock_knock/doctype/docket/docket.py
@@ -5,15 +5,10 @@ import frappe
 from frappe.utils import *
 from frappe.model.document import Document
 from knock_knock.knock_knock.utils import change_docket_status
-from knock_knock.knock_knock.utils import change_todo_status
 
 class Docket(Document):
 	def validate(self):
 		change_docket_status(self)
-
-	def validate(self):
-		change_todo_status(self)
-
 
 @frappe.whitelist()
 def add_docket_comment(name, new_date, reason=None):

--- a/knock_knock/knock_knock/doctype/docket/docket.py
+++ b/knock_knock/knock_knock/doctype/docket/docket.py
@@ -5,10 +5,15 @@ import frappe
 from frappe.utils import *
 from frappe.model.document import Document
 from knock_knock.knock_knock.utils import change_docket_status
+from knock_knock.knock_knock.utils import change_todo_status
 
 class Docket(Document):
 	def validate(self):
 		change_docket_status(self)
+
+	def validate(self):
+		change_todo_status(self)
+
 
 @frappe.whitelist()
 def add_docket_comment(name, new_date, reason=None):

--- a/knock_knock/knock_knock/utils.py
+++ b/knock_knock/knock_knock/utils.py
@@ -53,6 +53,21 @@ def get_all_dockets():
 					if due_date == today:
 						if mobile_no:
 							send_whatsapp_msg(mobile_no, docket_doc.description)
+
+#todo
+@frappe.whitelist()
+def get_all_todos():
+	if frappe.db.exists('ToDo', {'status': 'Open'}):
+		todos = frappe.db.get_all('ToDo', filters = {'status': 'Open'})
+		if todos:
+			for todo in todos:
+				todo_doc = frappe.get_doc('ToDo', todo.name)
+				today = getdate(frappe.utils.today())
+				due_date = getdate(todo_doc.date)
+				if due_date >= today:
+					change_todo_status(todo_doc)
+
+
 @frappe.whitelist()
 def send_whatsapp_msg(mobile_no, message_body):
 	whatsapp_communication_doc = frappe.new_doc("WhatsApp Communication")
@@ -83,3 +98,8 @@ def change_docket_status(self):
 			self.status = 'Overdue'
 			frappe.db.set_value(self.doctype, self.name, 'status', 'Overdue')
 			frappe.db.commit()
+#todo
+def change_todo_status(self):
+	self.status = 'Overdue'
+	frappe.db.set_value(self.doctype, self.name, 'status', 'Overdue')
+	frappe.db.commit()


### PR DESCRIPTION
## Feature description
Set the status to overdue immediately after duedate in ToDo.So that we can aware about the list of ToDo not done by the assigned one.




## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
![Screenshot from 2022-11-02 10-39-04](https://user-images.githubusercontent.com/95274912/199404755-c7ab6784-81a7-4994-9c29-08820b7e5323.png)


## Is there any existing behavior change of other features due to this code change?
no

## Was this feature tested on the browsers?
  - Chrome yes
  
