### PR TITLE
feat: Created a new doctype and re-arranged the fields in the Docket

### DIFF
--- a/knock_knock/knock_knock/doctype/docket/docket.js
+++ b/knock_knock/knock_knock/doctype/docket/docket.js
@@ -2,8 +2,13 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Docket', {
+  validate: function(frm){
+    if(frm.doc.remind_before_unit == ''){
+      frappe.throw({title:'ALERT !!', message: 'Remind before unit field is required!'})
+    }
+  },
   refresh: function(frm){
-    frm.set_df_property("due_date", "read_only", frm.is_new() ? 0 : 1);
+    frm.set_df_property('due_date', 'read_only', frm.is_new() ? 0 : 1);
     if (frm.doc.owner == frappe.session.user && !frm.is_new()){
       if (frm.doc.status == 'Open' || frm.doc.status == 'Overdue') {
         frm.set_df_property('change_due', 'hidden', 0)
@@ -52,5 +57,22 @@ frappe.ui.form.on('Docket', {
           }
       });
       command.show();
-}
+    },
+    due_date: function(frm){
+      if(frm.doc.due_date < frm.doc.posting_date){
+        frappe.throw({title:'ALERT !!',message: 'Cannot select past date in To date!'})
+      }
+    },
+    remind_before_unit: function(frm){
+      if(frm.doc.remind_before_unit == 'Day'){
+        frappe.db.get_single_value('Knock_settings', 'remind_before_day').then( remind_before_day=>{
+          frm.set_value('remind_before', remind_before_day)
+      })
+     }
+    if(frm.doc.remind_before_unit == 'Minutes'){
+      frappe.db.get_single_value('Knock_settings', 'remind_before_minute').then( remind_before_minute=>{
+        frm.set_value('remind_before',remind_before_minute)
+    })
+    }
+  }
 });

--- a/knock_knock/knock_knock/doctype/docket/docket.json
+++ b/knock_knock/knock_knock/doctype/docket/docket.json
@@ -9,14 +9,14 @@
  "field_order": [
   "naming_series",
   "subject",
-  "description",
-  "remind_before_unit",
-  "column_break_3",
-  "posting_date",
   "due_date",
   "change_due",
-  "status",
-  "remind_before"
+  "description",
+  "column_break_3",
+  "posting_date",
+  "remind_before_unit",
+  "remind_before",
+  "status"
  ],
  "fields": [
   {
@@ -35,6 +35,7 @@
    "default": "Now",
    "fieldname": "posting_date",
    "fieldtype": "Datetime",
+   "hidden": 1,
    "label": "Posting Date",
    "reqd": 1
   },
@@ -55,7 +56,6 @@
   {
    "fieldname": "remind_before_unit",
    "fieldtype": "Select",
-   "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Remind Before Unit ",
    "options": "\nDay\nMinutes"
@@ -74,6 +74,7 @@
   {
    "fieldname": "naming_series",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Series",
    "options": "DC.#####"
   },
@@ -86,11 +87,10 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-11-03 14:20:38.858769",
+ "modified": "2022-11-04 12:15:44.599793",
  "modified_by": "Administrator",
  "module": "Knock Knock",
  "name": "Docket",
- "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -108,5 +108,5 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "title_field": "subject"
 }

--- a/knock_knock/knock_knock/doctype/knock_settings/knock_settings.js
+++ b/knock_knock/knock_knock/doctype/knock_settings/knock_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, efeone Software Lab and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Knock_settings', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/knock_knock/knock_knock/doctype/knock_settings/knock_settings.json
+++ b/knock_knock/knock_knock/doctype/knock_settings/knock_settings.json
@@ -1,0 +1,47 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-11-04 10:10:09.049356",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "remind_before_day",
+  "remind_before_minute"
+ ],
+ "fields": [
+  {
+   "fieldname": "remind_before_day",
+   "fieldtype": "Int",
+   "label": "Remind Before Day"
+  },
+  {
+   "fieldname": "remind_before_minute",
+   "fieldtype": "Int",
+   "label": "Remind Before Minute",
+   "mandatory_depends_on": "eval:doc.remind_before_unit"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2022-11-04 14:27:21.556726",
+ "modified_by": "Administrator",
+ "module": "Knock Knock",
+ "name": "Knock_settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/knock_knock/knock_knock/doctype/knock_settings/knock_settings.py
+++ b/knock_knock/knock_knock/doctype/knock_settings/knock_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, efeone Software Lab and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class Knock_settings(Document):
+	pass

--- a/knock_knock/knock_knock/doctype/knock_settings/test_knock_settings.py
+++ b/knock_knock/knock_knock/doctype/knock_settings/test_knock_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, efeone Software Lab and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class TestKnock_settings(unittest.TestCase):
+	pass

--- a/knock_knock/knock_knock/utils.py
+++ b/knock_knock/knock_knock/utils.py
@@ -35,10 +35,10 @@ def daily_docket_scheduler():
 					notification_date = frappe.utils.add_to_date(due_date, days=-1*docket_doc.remind_before)
 				else:
 					notification_date = due_date
-				if getdate(notification_date) == current_date:
-					create_notification_log(docket_doc.subject, docket_doc.owner, docket_doc.description, docket_doc.doctype, docket_doc.name)
-					if mobile_no:
-						send_whatsapp_msg(mobile_no, docket_doc.description + '\nReference: ' + docket_url , docket_doc.doctype, docket_doc.name)
+			if getdate(notification_date) == current_date:
+				create_notification_log(docket_doc.subject, docket_doc.owner, docket_doc.description, docket_doc.doctype, docket_doc.name)
+				if mobile_no:
+					send_whatsapp_msg(mobile_no, docket_doc.description + '\nReference: ' + docket_url , docket_doc.doctype, docket_doc.name)
 
 @frappe.whitelist()
 def minute_docket_scheduler():
@@ -64,10 +64,10 @@ def minute_docket_scheduler():
 			if docket_doc.remind_before_unit == 'Minutes':
 				if due_date:
 					time_difference = int(time_diff(due_date, current_date_time).total_seconds() / 60)
-					if time_difference == docket_doc.remind_before:
-						create_notification_log(docket_doc.subject, docket_doc.owner, docket_doc.description, docket_doc.doctype, docket_doc.name)
-						if mobile_no:
-							send_whatsapp_msg(mobile_no, docket_doc.description+ '\nReference: ' + docket_url, docket_doc.doctype, docket_doc.name)
+			if time_difference == docket_doc.remind_before:
+				create_notification_log(docket_doc.subject, docket_doc.owner, docket_doc.description, docket_doc.doctype, docket_doc.name)
+				if mobile_no:
+					send_whatsapp_msg(mobile_no, docket_doc.description+ '\nReference: ' + docket_url, docket_doc.doctype, docket_doc.name)
 
 @frappe.whitelist()
 def daily_todo_scheduler():
@@ -117,7 +117,7 @@ def change_docket_status(self):
 		due_date = get_datetime(self.due_date)
 		if current_date >= due_date:
 			self.status = 'Overdue'
-			frappe.db.set_value(self.doctype, self.name, 'status', 'Overdue')
+			frappe.db.set_value(self.doctype, self.name, 'status', 'cancelled')
 			frappe.db.commit()
 #todo
 def change_todo_status(self):


### PR DESCRIPTION
## Feature description

->Created a new doctype Knock_settings to set default reminder for days and minutes . 
->Re-arranged the fields in doctype Docket.
->Set the validations for the due_date field and Remind_before_unit 



## Output screenshots (optional)
![Screenshot from 2022-11-04 15-35-14](https://user-images.githubusercontent.com/114916803/199950855-a417a94a-b7d9-49a9-9e32-45cc17cb6c20.png)
![Screenshot from 2022-11-04 15-34-04](https://user-images.githubusercontent.com/114916803/199950864-11a1797e-741a-4560-bd4b-91641c25fcfc.png)
![Screenshot from 2022-11-04 15-33-50](https://user-images.githubusercontent.com/114916803/199950868-b1708090-996b-45b6-9ca5-fc7ee454d7c8.png)
![Screenshot from 2022-11-04 15-33-27](https://user-images.githubusercontent.com/114916803/199950870-eb9662b8-9e0f-4385-91fa-fab4aa4fd8bb.png)


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome : yes

